### PR TITLE
BOMF-888 Address memory issue caused by not stopping batchFlushTicker.

### DIFF
--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -949,9 +949,7 @@ func (p *partitionProducer) closeFailedProducer() {
 	wg.Add(1)
 
 	cp := &closeProducer{&wg}
-	p.eventsChan <- cp
-
-	go p.runEventsLoop()
+	go p.internalClose(cp)
 
 	wg.Wait()
 }

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -145,7 +145,7 @@ func newPartitionProducer(client *client, topic string, options *ProducerOptions
 	// add default message crypto if not provided
 	if encryption != nil && len(encryption.Keys) > 0 {
 		if encryption.KeyReader == nil {
-			p.closFailedProducer()
+			p.closeFailedProducer()
 			return nil, fmt.Errorf("encryption is enabled, KeyReader can not be nil")
 		}
 
@@ -154,7 +154,7 @@ func newPartitionProducer(client *client, topic string, options *ProducerOptions
 			messageCrypto, err := crypto.NewDefaultMessageCrypto(logCtx, true, logger)
 			if err != nil {
 				logger.WithError(err).Error("Unable to get MessageCrypto instance. Producer creation is abandoned")
-				p.closFailedProducer()
+				p.closeFailedProducer()
 				return nil, err
 			}
 			p.options.Encryption.MessageCrypto = messageCrypto
@@ -164,7 +164,7 @@ func newPartitionProducer(client *client, topic string, options *ProducerOptions
 	err := p.grabCnx()
 	if err != nil {
 		logger.WithError(err).Error("Failed to create producer")
-		p.closFailedProducer()
+		p.closeFailedProducer()
 		return nil, err
 	}
 
@@ -942,7 +942,7 @@ func (i *pendingItem) Complete() {
 	buffersPool.Put(i.batchData)
 }
 
-func (p *partitionProducer) closFailedProducer() {
+func (p *partitionProducer) closeFailedProducer() {
 	p.setProducerState(producerFailed)
 
 	wg := sync.WaitGroup{}


### PR DESCRIPTION

### Motivation

The early returns from the newPartitionProducer without stopping the batchFlushTicker gradually caused many tickers to be created that were not being stopped. This gradually eats memory and caused the CPU to max out.

### Modifications

Altered the returns in the newPartitionProducer that were bypassing the cleanup that would stop the ticker.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)

### Documentation

  - This is a fix to address a memory / CPU issue
