### PR TITLE
Seek by time partitioned topic

### DIFF
--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -182,6 +182,13 @@ type ConsumerOptions struct {
 	// > Notice: the NackBackoffPolicy will not work with `consumer.NackID(MessageID)`
 	// > because we are not able to get the redeliveryCount from the message ID.
 	NackBackoffPolicy NackBackoffPolicy
+
+	// AckWithResponse is a return value added to Ack Command, and its purpose is to confirm whether Ack Command
+	// is executed correctly on the Broker side. When set to true, the error information returned by the Ack
+	// method contains the return value of the Ack Command processed by the Broker side; when set to false, the
+	// error information of the Ack method only contains errors that may occur in the Go SDK's own processing.
+	// Default: false
+	AckWithResponse bool
 }
 
 // Consumer is an interface that abstracts behavior of Pulsar's consumer

--- a/pulsar/consumer.go
+++ b/pulsar/consumer.go
@@ -200,10 +200,10 @@ type Consumer interface {
 	Chan() <-chan ConsumerMessage
 
 	// Ack the consumption of a single message
-	Ack(Message)
+	Ack(Message) error
 
 	// AckID the consumption of a single message, identified by its MessageID
-	AckID(MessageID)
+	AckID(MessageID) error
 
 	// ReconsumeLater mark a message for redelivery after custom delay
 	ReconsumeLater(msg Message, delay time.Duration)

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -589,14 +589,14 @@ func (c *consumer) Seek(msgID MessageID) error {
 func (c *consumer) SeekByTime(time time.Time) error {
 	c.Lock()
 	defer c.Unlock()
-	errChan := make(chan error, len(c.consumers))
+	errorSeek := make([]error, len(c.consumers))
 	// run SeekByTime on every partition of topic
-	for _, cons := range c.consumers {
-		errChan <- cons.SeekByTime(time)
+	for i, cons := range c.consumers {
+		errorSeek[i] = cons.SeekByTime(time)
 	}
 
 	// check if there are any errors on running SeekByTime on every partition of topic
-	for err := range errChan {
+	for _, err := range errorSeek {
 		if err != nil {
 			return newError(SeekFailed, err.Error())
 		}

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -361,6 +361,7 @@ func (c *consumer) internalTopicSubscribeToPartitions() error {
 				keySharedPolicy:            c.options.KeySharedPolicy,
 				schema:                     c.options.Schema,
 				decryption:                 c.options.Decryption,
+				ackWithResponse:            c.options.AckWithResponse,
 			}
 			cons, err := newPartitionConsumer(c, c.client, opts, c.messageCh, c.dlq, c.metrics)
 			ch <- ConsumerError{

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -19,6 +19,7 @@ package pulsar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -34,7 +35,7 @@ import (
 const defaultNackRedeliveryDelay = 1 * time.Minute
 
 type acker interface {
-	AckID(id trackingMessageID)
+	AckID(id trackingMessageID) error
 	NackID(id trackingMessageID)
 	NackMsg(msg Message)
 }
@@ -438,29 +439,28 @@ func (c *consumer) Receive(ctx context.Context) (message Message, err error) {
 	}
 }
 
-// Messages
+// Chan return the message chan to users
 func (c *consumer) Chan() <-chan ConsumerMessage {
 	return c.messageCh
 }
 
 // Ack the consumption of a single message
-func (c *consumer) Ack(msg Message) {
-	c.AckID(msg.ID())
+func (c *consumer) Ack(msg Message) error {
+	return c.AckID(msg.ID())
 }
 
-// Ack the consumption of a single message, identified by its MessageID
-func (c *consumer) AckID(msgID MessageID) {
+// AckID the consumption of a single message, identified by its MessageID
+func (c *consumer) AckID(msgID MessageID) error {
 	mid, ok := c.messageID(msgID)
 	if !ok {
-		return
+		return errors.New("failed to convert trackingMessageID")
 	}
 
 	if mid.consumer != nil {
-		mid.Ack()
-		return
+		return mid.Ack()
 	}
 
-	c.consumers[mid.partitionIdx].AckID(mid)
+	return c.consumers[mid.partitionIdx].AckID(mid)
 }
 
 // ReconsumeLater mark a message for redelivery after custom delay

--- a/pulsar/consumer_multitopic.go
+++ b/pulsar/consumer_multitopic.go
@@ -19,6 +19,7 @@ package pulsar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -112,30 +113,30 @@ func (c *multiTopicConsumer) Receive(ctx context.Context) (message Message, err 
 	}
 }
 
-// Messages
+// Chan return the message chan to users
 func (c *multiTopicConsumer) Chan() <-chan ConsumerMessage {
 	return c.messageCh
 }
 
 // Ack the consumption of a single message
-func (c *multiTopicConsumer) Ack(msg Message) {
-	c.AckID(msg.ID())
+func (c *multiTopicConsumer) Ack(msg Message) error {
+	return c.AckID(msg.ID())
 }
 
-// Ack the consumption of a single message, identified by its MessageID
-func (c *multiTopicConsumer) AckID(msgID MessageID) {
+// AckID the consumption of a single message, identified by its MessageID
+func (c *multiTopicConsumer) AckID(msgID MessageID) error {
 	mid, ok := toTrackingMessageID(msgID)
 	if !ok {
 		c.log.Warnf("invalid message id type %T", msgID)
-		return
+		return errors.New("invalid message id type in multi_consumer")
 	}
 
 	if mid.consumer == nil {
 		c.log.Warnf("unable to ack messageID=%+v can not determine topic", msgID)
-		return
+		return errors.New("unable to ack message because consumer is nil")
 	}
 
-	mid.Ack()
+	return mid.Ack()
 }
 
 func (c *multiTopicConsumer) ReconsumeLater(msg Message, delay time.Duration) {

--- a/pulsar/consumer_partition_test.go
+++ b/pulsar/consumer_partition_test.go
@@ -21,11 +21,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/apache/pulsar-client-go/pulsar/internal/crypto"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/apache/pulsar-client-go/pulsar/internal"
+	"github.com/apache/pulsar-client-go/pulsar/internal/crypto"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSingleMessageIDNoAckTracker(t *testing.T) {

--- a/pulsar/consumer_regex.go
+++ b/pulsar/consumer_regex.go
@@ -19,6 +19,7 @@ package pulsar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -152,34 +153,34 @@ func (c *regexConsumer) Receive(ctx context.Context) (message Message, err error
 	}
 }
 
-// Chan
+// Chan return the messages chan to user
 func (c *regexConsumer) Chan() <-chan ConsumerMessage {
 	return c.messageCh
 }
 
 // Ack the consumption of a single message
-func (c *regexConsumer) Ack(msg Message) {
-	c.AckID(msg.ID())
+func (c *regexConsumer) Ack(msg Message) error {
+	return c.AckID(msg.ID())
 }
 
 func (c *regexConsumer) ReconsumeLater(msg Message, delay time.Duration) {
 	c.log.Warnf("regexp consumer not support ReconsumeLater yet.")
 }
 
-// Ack the consumption of a single message, identified by its MessageID
-func (c *regexConsumer) AckID(msgID MessageID) {
+// AckID the consumption of a single message, identified by its MessageID
+func (c *regexConsumer) AckID(msgID MessageID) error {
 	mid, ok := toTrackingMessageID(msgID)
 	if !ok {
 		c.log.Warnf("invalid message id type %T", msgID)
-		return
+		return errors.New("invalid message id type")
 	}
 
 	if mid.consumer == nil {
 		c.log.Warnf("unable to ack messageID=%+v can not determine topic", msgID)
-		return
+		return errors.New("consumer is nil in consumer_regex")
 	}
 
-	mid.Ack()
+	return mid.Ack()
 }
 
 func (c *regexConsumer) Nack(msg Message) {

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -3052,3 +3052,76 @@ func TestEncryptDecryptRedeliveryOnFailure(t *testing.T) {
 	assert.NotNil(t, msg)
 	consumer.Ack(msg)
 }
+
+// TestConsumerSeekByTimeOnPartitionedTopic test seek by time on partitioned topic.
+// It is based on existing test case [TestConsumerSeekByTime] but for partitioned topic.
+func TestConsumerSeekByTimeOnPartitionedTopic(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+	assert.Nil(t, err)
+	defer client.Close()
+
+	// Create topic with 5 partitions
+	topicAdminURL := "admin/v2/persistent/public/default/TestSeekByTimeOnPartitionedTopic/partitions"
+	err = httpPut(topicAdminURL, 5)
+	defer httpDelete(topicAdminURL)
+	assert.Nil(t, err)
+
+	topicName := "persistent://public/default/TestSeekByTimeOnPartitionedTopic"
+
+	partitions, err := client.TopicPartitions(topicName)
+	assert.Nil(t, err)
+	assert.Equal(t, len(partitions), 5)
+	for i := 0; i < 5; i++ {
+		assert.Equal(t, partitions[i],
+			fmt.Sprintf("%s-partition-%d", topicName, i))
+	}
+
+	ctx := context.Background()
+
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:           topicName,
+		DisableBatching: false,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	consumer, err := client.Subscribe(ConsumerOptions{
+		Topic:            topicName,
+		SubscriptionName: "my-sub",
+	})
+	assert.Nil(t, err)
+	defer consumer.Close()
+
+	// Use value bigger than 1000 to full-fill queue channel with size 1000 and message channel with size 10
+	const N = 1100
+	resetTimeStr := "100s"
+	retentionTimeInSecond, err := internal.ParseRelativeTimeInSeconds(resetTimeStr)
+	assert.Nil(t, err)
+
+	for i := 0; i < N; i++ {
+		_, err := producer.Send(ctx, &ProducerMessage{
+			Payload: []byte(fmt.Sprintf("hello-%d", i)),
+		})
+		assert.Nil(t, err)
+	}
+
+	// Don't consume all messages so some stay in queues
+	for i := 0; i < N-20; i++ {
+		msg, err := consumer.Receive(ctx)
+		assert.Nil(t, err)
+		consumer.Ack(msg)
+	}
+
+	currentTimestamp := time.Now()
+	err = consumer.SeekByTime(currentTimestamp.Add(-retentionTimeInSecond))
+	assert.Nil(t, err)
+
+	// should be able to consume all messages once again
+	for i := 0; i < N; i++ {
+		msg, err := consumer.Receive(ctx)
+		assert.Nil(t, err)
+		consumer.Ack(msg)
+	}
+}

--- a/pulsar/impl_message.go
+++ b/pulsar/impl_message.go
@@ -18,6 +18,7 @@
 package pulsar
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -63,13 +64,15 @@ func (id trackingMessageID) Undefined() bool {
 	return id == trackingMessageID{}
 }
 
-func (id trackingMessageID) Ack() {
+func (id trackingMessageID) Ack() error {
 	if id.consumer == nil {
-		return
+		return errors.New("consumer is nil in trackingMessageID")
 	}
 	if id.ack() {
-		id.consumer.AckID(id)
+		return id.consumer.AckID(id)
 	}
+
+	return nil
 }
 
 func (id trackingMessageID) Nack() {

--- a/pulsar/internal/connection.go
+++ b/pulsar/internal/connection.go
@@ -823,8 +823,6 @@ func (c *connection) handleCloseConsumer(closeConsumer *pb.CommandCloseConsumer)
 	consumerID := closeConsumer.GetConsumerId()
 	c.log.Infof("Broker notification of Closed consumer: %d", consumerID)
 
-	c.changeState(connectionClosed)
-
 	if consumer, ok := c.consumerHandler(consumerID); ok {
 		consumer.ConnectionClosed()
 		c.DeleteConsumeHandler(consumerID)
@@ -836,8 +834,6 @@ func (c *connection) handleCloseConsumer(closeConsumer *pb.CommandCloseConsumer)
 func (c *connection) handleCloseProducer(closeProducer *pb.CommandCloseProducer) {
 	c.log.Infof("Broker notification of Closed producer: %d", closeProducer.GetProducerId())
 	producerID := closeProducer.GetProducerId()
-
-	c.changeState(connectionClosed)
 
 	producer, ok := c.deletePendingProducers(producerID)
 	// did we find a producer?

--- a/pulsar/internal/connection_pool.go
+++ b/pulsar/internal/connection_pool.go
@@ -78,7 +78,9 @@ func (p *connectionPool) GetConnection(logicalAddr *url.URL, physicalAddr *url.U
 		p.log.Debugf("Found connection in pool key=%s logical_addr=%+v physical_addr=%+v",
 			key, conn.logicalAddr, conn.physicalAddr)
 
-		// remove stale/failed connection
+		// When the current connection is in a closed state or the broker actively notifies that the
+		// current connection is closed, we need to remove the connection object from the current
+		// connection pool and create a new connection.
 		if conn.closed() {
 			p.log.Infof("Removed connection from pool key=%s logical_addr=%+v physical_addr=%+v",
 				key, conn.logicalAddr, conn.physicalAddr)

--- a/pulsar/internal/connection_pool.go
+++ b/pulsar/internal/connection_pool.go
@@ -82,7 +82,7 @@ func (p *connectionPool) GetConnection(logicalAddr *url.URL, physicalAddr *url.U
 		// current connection is closed, we need to remove the connection object from the current
 		// connection pool and create a new connection.
 		if conn.closed() {
-			p.log.Infof("Removed connection from pool key=%s logical_addr=%+v physical_addr=%+v",
+			p.log.Debugf("Removed connection from pool key=%s logical_addr=%+v physical_addr=%+v",
 				key, conn.logicalAddr, conn.physicalAddr)
 			delete(p.connections, key)
 			conn.Close()

--- a/pulsar/internal/metrics.go
+++ b/pulsar/internal/metrics.go
@@ -482,7 +482,10 @@ func NewMetricsProvider(metricsCardinality int, userDefinedLabels map[string]str
 
 func (mp *Metrics) GetLeveledMetrics(t string) *LeveledMetrics {
 	labels := make(map[string]string, 3)
-	tn, _ := ParseTopicName(t)
+	tn, err := ParseTopicName(t)
+	if err != nil {
+		return nil
+	}
 	topic := TopicNameWithoutPartitionPart(tn)
 	switch mp.metricsLevel {
 	case 4:

--- a/pulsar/internal/pulsartracing/consumer_interceptor_test.go
+++ b/pulsar/internal/pulsartracing/consumer_interceptor_test.go
@@ -64,9 +64,13 @@ func (c *mockConsumer) Chan() <-chan pulsar.ConsumerMessage {
 	return nil
 }
 
-func (c *mockConsumer) Ack(msg pulsar.Message) {}
+func (c *mockConsumer) Ack(msg pulsar.Message) error {
+	return nil
+}
 
-func (c *mockConsumer) AckID(msgID pulsar.MessageID) {}
+func (c *mockConsumer) AckID(msgID pulsar.MessageID) error {
+	return nil
+}
 
 func (c *mockConsumer) ReconsumeLater(msg pulsar.Message, delay time.Duration) {}
 

--- a/pulsar/internal/topic_name.go
+++ b/pulsar/internal/topic_name.go
@@ -107,6 +107,9 @@ func ParseTopicName(topic string) (*TopicName, error) {
 }
 
 func TopicNameWithoutPartitionPart(tn *TopicName) string {
+	if tn == nil {
+		return ""
+	}
 	if tn.Partition < 0 {
 		return tn.Name
 	}

--- a/pulsar/internal/topic_name_test.go
+++ b/pulsar/internal/topic_name_test.go
@@ -104,20 +104,24 @@ func TestParseTopicNameErrors(t *testing.T) {
 
 func TestTopicNameWithoutPartitionPart(t *testing.T) {
 	tests := []struct {
-		tn       TopicName
+		tn       *TopicName
 		expected string
 	}{
 		{
-			tn:       TopicName{Name: "persistent://public/default/my-topic", Partition: -1},
+			tn:       &TopicName{Name: "persistent://public/default/my-topic", Partition: -1},
 			expected: "persistent://public/default/my-topic",
 		},
 		{
-			tn:       TopicName{Name: "persistent://public/default/my-topic-partition-0", Partition: 0},
+			tn:       &TopicName{Name: "persistent://public/default/my-topic-partition-0", Partition: 0},
 			expected: "persistent://public/default/my-topic",
+		},
+		{
+			tn:       nil,
+			expected: "",
 		},
 	}
 	for _, test := range tests {
-		assert.Equal(t, test.expected, TopicNameWithoutPartitionPart(&test.tn))
+		assert.Equal(t, test.expected, TopicNameWithoutPartitionPart(test.tn))
 	}
 }
 

--- a/pulsar/producer_partition.go
+++ b/pulsar/producer_partition.go
@@ -785,15 +785,15 @@ func (p *partitionProducer) ReceivedSendReceipt(response *pb.CommandSendReceipt)
 	}
 
 	if pi.sequenceID < response.GetSequenceId() {
-		// Ignoring the ack since it's referring to a message that has already timed out.
-		p.log.Warnf("Received ack for %v on sequenceId %v - expected: %v, closing connection", response.GetMessageId(),
-			response.GetSequenceId(), pi.sequenceID)
-		return
-	} else if pi.sequenceID > response.GetSequenceId() {
 		// Force connection closing so that messages can be re-transmitted in a new connection
 		p.log.Warnf("Received ack for %v on sequenceId %v - expected: %v, closing connection", response.GetMessageId(),
 			response.GetSequenceId(), pi.sequenceID)
 		p._getConn().Close()
+		return
+	} else if pi.sequenceID > response.GetSequenceId() {
+		// Ignoring the ack since it's referring to a message that has already timed out.
+		p.log.Warnf("Received ack for %v on sequenceId %v - expected: %v, closing connection", response.GetMessageId(),
+			response.GetSequenceId(), pi.sequenceID)
 		return
 	} else {
 		// The ack was indeed for the expected item in the queue, we can remove it and trigger the callback


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-go/issues/781

Motivation
Currently there is no way for a consumer subscription to seek by time on partitioned topics. Changes in the PR supports this feature.

Modifications
Changed SeekByTime method to add support for partitioned topics