### PR TITLE
Seek by time partitioned topic

### DIFF
--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -589,14 +589,14 @@ func (c *consumer) Seek(msgID MessageID) error {
 func (c *consumer) SeekByTime(time time.Time) error {
 	c.Lock()
 	defer c.Unlock()
-	errChan := make(chan error, len(c.consumers))
+	errorSeek := make([]error, len(c.consumers))
 	// run SeekByTime on every partition of topic
-	for _, cons := range c.consumers {
-		errChan <- cons.SeekByTime(time)
+	for i, cons := range c.consumers {
+		errorSeek[i] = cons.SeekByTime(time)
 	}
 
 	// check if there are any errors on running SeekByTime on every partition of topic
-	for err := range errChan {
+	for _, err := range errorSeek {
 		if err != nil {
 			return newError(SeekFailed, err.Error())
 		}

--- a/pulsar/consumer_impl.go
+++ b/pulsar/consumer_impl.go
@@ -590,21 +590,14 @@ func (c *consumer) Seek(msgID MessageID) error {
 func (c *consumer) SeekByTime(time time.Time) error {
 	c.Lock()
 	defer c.Unlock()
-	errorSeek := make([]error, len(c.consumers))
-	// run SeekByTime on every partition of topic
-	for i, cons := range c.consumers {
-		errorSeek[i] = cons.SeekByTime(time)
-	}
-
 	var errs error
-	// check if there are any errors on running SeekByTime on every partition of topic
-	for _, err := range errorSeek {
-		if err != nil {
-			msg := fmt.Sprintf("unable to SeekByTime for topic=%s partition=%s", c.topic, c.Subscription())
+	// run SeekByTime on every partition of topic
+	for _, cons := range c.consumers {
+		if err := cons.SeekByTime(time); err != nil {
+			msg := fmt.Sprintf("unable to SeekByTime for topic=%s subscription=%s", c.topic, c.Subscription())
 			errs = pkgerrors.Wrap(newError(SeekFailed, err.Error()), msg)
 		}
 	}
-
 	return errs
 }
 

--- a/pulsar/consumer_test.go
+++ b/pulsar/consumer_test.go
@@ -3052,3 +3052,76 @@ func TestEncryptDecryptRedeliveryOnFailure(t *testing.T) {
 	assert.NotNil(t, msg)
 	consumer.Ack(msg)
 }
+
+// TestConsumerSeekByTimeOnPartitionedTopic test seek by time on partitioned topic.
+// It is based on existing test case [TestConsumerSeekByTime] but for partitioned topic.
+func TestConsumerSeekByTimeOnPartitionedTopic(t *testing.T) {
+	client, err := NewClient(ClientOptions{
+		URL: lookupURL,
+	})
+	assert.Nil(t, err)
+	defer client.Close()
+
+	// Create topic with 5 partitions
+	topicAdminURL := "admin/v2/persistent/public/default/TestSeekByTimeOnPartitionedTopic/partitions"
+	err = httpPut(topicAdminURL, 5)
+	defer httpDelete(topicAdminURL)
+	assert.Nil(t, err)
+
+	topicName := "persistent://public/default/TestSeekByTimeOnPartitionedTopic"
+
+	partitions, err := client.TopicPartitions(topicName)
+	assert.Nil(t, err)
+	assert.Equal(t, len(partitions), 5)
+	for i := 0; i < 5; i++ {
+		assert.Equal(t, partitions[i],
+			fmt.Sprintf("%s-partition-%d", topicName, i))
+	}
+
+	ctx := context.Background()
+
+	producer, err := client.CreateProducer(ProducerOptions{
+		Topic:           topicName,
+		DisableBatching: false,
+	})
+	assert.Nil(t, err)
+	defer producer.Close()
+
+	consumer, err := client.Subscribe(ConsumerOptions{
+		Topic:            topicName,
+		SubscriptionName: "my-sub",
+	})
+	assert.Nil(t, err)
+	defer consumer.Close()
+
+	// Use value bigger than 1000 to full-fill queue channel with size 1000 and message channel with size 10
+	const N = 1100
+	resetTimeStr := "100s"
+	retentionTimeInSecond, err := internal.ParseRelativeTimeInSeconds(resetTimeStr)
+	assert.Nil(t, err)
+
+	for i := 0; i < N; i++ {
+		_, err := producer.Send(ctx, &ProducerMessage{
+			Payload: []byte(fmt.Sprintf("hello-%d", i)),
+		})
+		assert.Nil(t, err)
+	}
+
+	// Don't consume all messages so some stay in queues
+	for i := 0; i < N-20; i++ {
+		msg, err := consumer.Receive(ctx)
+		assert.Nil(t, err)
+		consumer.Ack(msg)
+	}
+
+	currentTimestamp := time.Now()
+	err = consumer.SeekByTime(currentTimestamp.Add(-retentionTimeInSecond))
+	assert.Nil(t, err)
+
+	// should be able to consume all messages once again
+	for i := 0; i < N; i++ {
+		msg, err := consumer.Receive(ctx)
+		assert.Nil(t, err)
+		consumer.Ack(msg)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar-client-go/issues/781

Motivation
Currently there is no way for a consumer subscription to seek by time on partitioned topics. Changes in the PR supports this feature.

Modifications
Changed SeekByTime method to add support for partitioned topics

Verifying this change
 Make sure that the change passes the CI checks.